### PR TITLE
fix for issue #4

### DIFF
--- a/src/main/java/thothbot/parallax/core/client/renderers/WebGLRenderer.java
+++ b/src/main/java/thothbot/parallax/core/client/renderers/WebGLRenderer.java
@@ -1523,7 +1523,6 @@ public class WebGLRenderer implements HasEventBus
 		{
 			this.cache_currentMaterialId = material.getId();
 			refreshMaterial = true;
-			Log.error("material.getId() != this.cache_currentMaterialId");
 		}
 
 		if ( refreshMaterial || camera != this.cache_currentCamera ) 


### PR DESCRIPTION
prevent log spamming for material.getId() != this.cache_currentMaterialId as the latter is reset before every frame rendering.
