### PR TITLE
fix #26

### DIFF
--- a/src/thothbot/parallax/core/client/renderers/WebGLRenderer.java
+++ b/src/thothbot/parallax/core/client/renderers/WebGLRenderer.java
@@ -2981,8 +2981,8 @@ public class WebGLRenderer implements HasEventBus
 			getGL().pixelStorei( PixelStoreParameter.UNPACK_ALIGNMENT, texture.getUnpackAlignment() );
 
 			Element image = texture.getImage();
-			boolean isImagePowerOfTwo = Mathematics.isPowerOfTwo( image.getOffsetWidth() ) 
-					&& Mathematics.isPowerOfTwo( image.getOffsetHeight() );
+			boolean isImagePowerOfTwo = Mathematics.isPowerOfTwo( texture.getWidth() ) 
+					&& Mathematics.isPowerOfTwo( texture.getHeight() );
 
 			texture.setTextureParameters( getGL(), getMaxAnisotropy(), TextureTarget.TEXTURE_2D, isImagePowerOfTwo );
 
@@ -3029,6 +3029,10 @@ public class WebGLRenderer implements HasEventBus
 	{
 		int width = image.getOffsetWidth();
 		int height = image.getOffsetHeight();
+        if (width == 0 && height == 0) {
+            width = image.getPropertyInt("width");
+            height = image.getPropertyInt("height");
+        }
 		
 		CanvasElement canvas = Document.get().createElement("canvas").cast();
 		
@@ -3055,6 +3059,10 @@ public class WebGLRenderer implements HasEventBus
 	{
 		int imgWidth = image.getOffsetWidth();
 		int imgHeight = image.getOffsetHeight();
+        if (imgWidth == 0 && imgHeight == 0) {
+            imgWidth = image.getPropertyInt("width");
+            imgHeight = image.getPropertyInt("height");
+        }
 
 		if ( imgWidth <= maxSize && imgHeight <= maxSize )
 			return image;

--- a/src/thothbot/parallax/core/client/textures/Texture.java
+++ b/src/thothbot/parallax/core/client/textures/Texture.java
@@ -328,6 +328,32 @@ public class Texture
 		this.image = image;
 	}
 
+    /**
+     * Gets texture width.
+     * 
+     * @return the texture width.
+     */
+	public int getWidth() {
+	    int width = image.getOffsetWidth();
+	    if (width == 0) {
+	        width = image.getPropertyInt("width");
+	    }
+	    return width;
+	}
+
+    /**
+     * Gets texture height.
+     * 
+     * @return the texture height.
+     */
+    public int getHeight() {
+        int height = image.getOffsetHeight();
+        if (height == 0) {
+            height = image.getPropertyInt("height");
+        }
+        return height;
+    }
+    
 	/**
 	 * Gets texture offset.
 	 * 


### PR DESCRIPTION
Patch proposal to fix #26
When DOM elements are detached from the document, offsetWidth/Height are always 0: whereas the element may have proper size set in width/height attributes. This patch adds a fallback on width/height properties when offsetWidth/Height are 0. It allows to use a canvas as a texture without having to attach it first.