### PR TITLE
Make the setSize method of RenderingPanel protected

### DIFF
--- a/src/thothbot/parallax/core/client/RenderingPanel.java
+++ b/src/thothbot/parallax/core/client/RenderingPanel.java
@@ -311,7 +311,7 @@ public class RenderingPanel extends LayoutPanel implements IsWidget, HasWidgets,
 	 * @param width  the new width of the {@link Canvas3d}.
 	 * @param height the new height of the {@link Canvas3d}.
 	 */
-	private void setSize(int width, int height) 
+	protected void setSize(int width, int height) 
 	{
 		Log.debug("RenderingPanel: set size: W=" + width + ", H=" + height); 
 


### PR DESCRIPTION
The offsetWidth and offsetHeight may not work as expected in some scenarios. It is important to give a choice to the developer in those cases. We have hit that bug on chrome. The offsetWidth stopped working if the root panel is in an iframe. Therefore, it could be good to make the setSize method of RenderingPanel  overridable.