### PR TITLE
Put GLSL #extension directive first.

### DIFF
--- a/src/thothbot/parallax/core/client/renderers/WebGLRenderer.java
+++ b/src/thothbot/parallax/core/client/renderers/WebGLRenderer.java
@@ -340,7 +340,7 @@ public class WebGLRenderer extends AbstractRenderer implements HasEventBus
 		
 		if ( _logarithmicDepthBuffer ) 
 		{
-			WebGLExtensions.get(gl, WebGLExtensions.Id.EXT_frag_depth);
+			_logarithmicDepthBuffer = WebGLExtensions.get(gl, WebGLExtensions.Id.EXT_frag_depth);
 		}
 		
 		WebGLCompressedTextureS3tc GLExtensionCompressedTextureS3TC = (WebGLCompressedTextureS3tc) gl.getExtension( "WEBGL_compressed_texture_s3tc" );

--- a/src/thothbot/parallax/core/client/shaders/Shader.java
+++ b/src/thothbot/parallax/core/client/shaders/Shader.java
@@ -80,6 +80,9 @@ public abstract class Shader
 	private String vertexShaderSource = "";
 	private String fragmentShaderSource = "";
 
+	private String vertexExtensions = "";
+	private String fragmentExtensions = "";
+
 	private boolean cache_areCustomAttributesDirty;
 
 	private int id;
@@ -206,8 +209,8 @@ public abstract class Shader
 
 		this.program = gl.createProgram();
 
-		String vertex = getShaderPrecisionDefinition() + "\n" + getVertexSource();
-		String fragment = getShaderPrecisionDefinition() + "\n" + getFragmentSource();
+		String vertex = vertexExtensions + getShaderPrecisionDefinition() + "\n" + getVertexSource();
+		String fragment = fragmentExtensions + getShaderPrecisionDefinition() + "\n" + getFragmentSource();
 		
 		WebGLShader glVertexShader = getShaderProgram(gl, ChunksVertexShader.class, vertex);
 		WebGLShader glFragmentShader = getShaderProgram(gl, ChunksFragmentShader.class, fragment); 
@@ -275,8 +278,13 @@ public abstract class Shader
 		return this.vertexShaderSource;
 	}
 
+	public void setVertexExtensions(String vertexExtensions)
+	{
+		this.vertexExtensions = vertexExtensions;
+	}
+
 	public void setVertexSource(String src) {
-		this.vertexShaderSource = src;		
+		this.vertexShaderSource = src;
 	}
 	
 	protected void updateVertexSource(String src) {
@@ -295,7 +303,12 @@ public abstract class Shader
 	public void setFragmentSource(String src) {
 		this.fragmentShaderSource = src;		
 	}
-	
+
+	public void setFragmentExtensions(String fragmentExtensions)
+	{
+		this.fragmentExtensions = fragmentExtensions;
+	}
+
 	protected void updateFragmentSource(String src) {
 		setFragmentSource(src);		
 	}

--- a/src/thothbot/parallax/core/client/shaders/chunk/logdepthbuf_par_fragment.glsl
+++ b/src/thothbot/parallax/core/client/shaders/chunk/logdepthbuf_par_fragment.glsl
@@ -4,7 +4,6 @@
 
 	#ifdef USE_LOGDEPTHBUF_EXT
 
-		#extension GL_EXT_frag_depth : enable
 		varying float vFragDepth;
 
 	#endif

--- a/src/thothbot/parallax/core/shared/materials/Material.java
+++ b/src/thothbot/parallax/core/shared/materials/Material.java
@@ -516,12 +516,20 @@ public abstract class Material
 	{
 		Shader shader = getShader();
 
+		shader.setVertexExtensions(getExtensionsVertex(parameters));
+		shader.setFragmentExtensions(getExtensionsFragment(parameters));
+
 		shader.setVertexSource(getPrefixVertex(parameters) + "\n" + shader.getVertexSource());
 		shader.setFragmentSource(getPrefixFragment(parameters) + "\n" + shader.getFragmentSource());
 
 		this.shader = shader.buildProgram(gl, parameters.useVertexTexture, parameters.maxMorphTargets, parameters.maxMorphNormals);
 
 		return this.shader;
+	}
+
+	private String getExtensionsVertex(ProgramParameters parameters)
+	{
+		return "";
 	}
 
 	private String getPrefixVertex(ProgramParameters parameters)
@@ -662,6 +670,14 @@ public abstract class Material
 
 		return retval;
 	}
+  
+	private String getExtensionsFragment(ProgramParameters parameters)
+	{
+		if (parameters.bumpMap || parameters.normalMap)
+			return "#extension GL_OES_standard_derivatives : enable\n\n";
+		else
+			return "";
+	}
 
 	private String getPrefixFragment(ProgramParameters parameters)
 	{
@@ -670,9 +686,6 @@ public abstract class Material
 
 		options.add("");
 		
-		if(parameters.bumpMap || parameters.normalMap)
-			options.add("#extension GL_OES_standard_derivatives : enable");
-
 		options.add(SHADER_DEFINE.MAX_DIR_LIGHTS.getValue(parameters.maxDirLights));
 		options.add(SHADER_DEFINE.MAX_POINT_LIGHTS.getValue(parameters.maxPointLights));
 		options.add(SHADER_DEFINE.MAX_SPOT_LIGHTS.getValue(parameters.maxSpotLights));

--- a/src/thothbot/parallax/core/shared/materials/Material.java
+++ b/src/thothbot/parallax/core/shared/materials/Material.java
@@ -673,10 +673,12 @@ public abstract class Material
   
 	private String getExtensionsFragment(ProgramParameters parameters)
 	{
+		String s = "";
+		if (parameters.logarithmicDepthBuffer)
+			s += "#extension GL_EXT_frag_depth : enable\n\n";
 		if (parameters.bumpMap || parameters.normalMap)
-			return "#extension GL_OES_standard_derivatives : enable\n\n";
-		else
-			return "";
+			s += "#extension GL_OES_standard_derivatives : enable\n\n";
+		return s;
 	}
 
 	private String getPrefixFragment(ProgramParameters parameters)


### PR DESCRIPTION
I ran into a shader bug while working on the bump mapping demo (human head). When compiling I got this error:

0:3: P0001: Extension directive must occur before any non-preprocessor tokens

which was caused by the #extension directive coming after the precision directive. I've made some changes to fix this, which can be applied to your fork, but I think one of the shader chunks, logdepthbuf_par_fragment.glsl, will also run into this problem, and I haven't dealt with that yet. Whatever fix I come up for that will be more difficult to merge into your version because I had to devise a different way of making the glsl files available in Java: I used a script to turn them all into Strings in Java classes.

I think this bug is also in three.js.