### PR TITLE
Apply max available precision to shaders.

### DIFF
--- a/src/thothbot/parallax/core/shared/materials/Material.java
+++ b/src/thothbot/parallax/core/shared/materials/Material.java
@@ -516,6 +516,8 @@ public abstract class Material
 	{
 		Shader shader = getShader();
 
+		shader.setPrecision(parameters.precision);
+
 		shader.setVertexExtensions(getExtensionsVertex(parameters));
 		shader.setFragmentExtensions(getExtensionsFragment(parameters));
 


### PR DESCRIPTION
WebGLRenderer detects whether the maximum supported shader precision is lowp, mediump or highp, but it wasn't actually using that information when building shaders, and defaulting to highp. My phone only supports up to mediump but just seemed to ignore the highp, but it's probably a good idea to patch this anyway.

FWIW I discovered the issue because I've ported it to libgdx too and the precision directives have to be removed altogether for OpenGL 2.0 (non-ES).