### PR TITLE
multiple code improvements: squid:S1213, squid:S2131, squid:S1155, squid:CommentedOutCodeLine, squid:S00122, squid:S2184, squid:S00115, squid:UselessParenthesesCheck, squid:S1192, squid:S1905

### DIFF
--- a/extensions/parallax-renderer-plugins/src/org/parallax3d/parallax/graphics/renderers/plugins/effects/OculusRift.java
+++ b/extensions/parallax-renderer-plugins/src/org/parallax3d/parallax/graphics/renderers/plugins/effects/OculusRift.java
@@ -160,13 +160,13 @@ public class OculusRift extends Effect {
 		this.hdm = hdm;
 
 		// Compute aspect ratio and FOV
-		double aspect = (double)hdm.hResolution / (double)(2.0 * hdm.vResolution);
+		double aspect = (double)hdm.hResolution / (2.0 * hdm.vResolution);
 
 		// Fov is normally computed with:
 		//   THREE.Math.radToDeg( 2*Math.atan2(HMD.vScreenSize,2*HMD.eyeToScreenDistance) );
 		// But with lens distortion it is increased (see Oculus SDK Documentation)
 		double r = -1.0 - (4.0 * (hdm.hScreenSize/4.0 - hdm.lensSeparationDistance/2.0) / hdm.hScreenSize);
-		distScale = (hdm.distortionK[0] + hdm.distortionK[1] * Math.pow(r,2) + hdm.distortionK[2] * Math.pow(r,4) + hdm.distortionK[3] * Math.pow(r,6));
+		distScale = hdm.distortionK[0] + hdm.distortionK[1] * Math.pow(r,2) + hdm.distortionK[2] * Math.pow(r,4) + hdm.distortionK[3] * Math.pow(r,6);
 		double fov = Mathematics.radToDeg(2.0 * Math.atan2(hdm.vScreenSize * distScale, 2.0 * hdm.eyeToScreenDistance));
 
 		// Compute camera projection matrices

--- a/extensions/parallax-renderer-plugins/src/org/parallax3d/parallax/graphics/renderers/plugins/sprite/SpritePlugin.java
+++ b/extensions/parallax-renderer-plugins/src/org/parallax3d/parallax/graphics/renderers/plugins/sprite/SpritePlugin.java
@@ -43,8 +43,6 @@ import java.util.Map;
 
 public final class SpritePlugin extends Plugin
 {
-	private List<Sprite> objects;
-	
 	Float32Array vertices;
 	Uint16Array faces;
 	
@@ -58,7 +56,11 @@ public final class SpritePlugin extends Plugin
 	Vector3 spritePosition = new Vector3();
 	Quaternion spriteRotation = new Quaternion();
 	Vector3 spriteScale = new Vector3();
-		
+	
+	private List<Sprite> objects;
+
+	private static final String FOG_TYPE = "fogType";
+
 	public SpritePlugin(GLRenderer renderer, Scene scene)
 	{
 		super(renderer, scene);
@@ -97,7 +99,7 @@ public final class SpritePlugin extends Plugin
 	
 	public List<Sprite> getObjects() 
 	{
-		if(this.objects == null || this.objects.size() == 0)
+		if(this.objects == null || this.objects.isEmpty())
 		{
 			this.objects = (List<Sprite>)(ArrayList)getScene().getChildrenByClass(Sprite.class, true);
 		}
@@ -150,7 +152,7 @@ public final class SpritePlugin extends Plugin
 				gl.glUniform1f( uniforms.get("fogNear").getLocation(), (float) ((Fog)fog).getNear() );
 				gl.glUniform1f( uniforms.get("fogFar").getLocation(), (float) ((Fog)fog).getFar() );
 
-				gl.glUniform1i( uniforms.get("fogType").getLocation(), 1 );
+				gl.glUniform1i( uniforms.get(FOG_TYPE).getLocation(), 1 );
 				oldFogType = 1;
 				sceneFogType = 1;
 
@@ -158,7 +160,7 @@ public final class SpritePlugin extends Plugin
 
 				gl.glUniform1f( uniforms.get("fogDensity").getLocation(), (float)((FogExp2)fog).getDensity() );
 
-				gl.glUniform1i( uniforms.get("fogType").getLocation(), 2 );
+				gl.glUniform1i( uniforms.get(FOG_TYPE).getLocation(), 2 );
 				oldFogType = 2;
 				sceneFogType = 2;
 
@@ -166,7 +168,7 @@ public final class SpritePlugin extends Plugin
 
 		} else {
 
-			gl.glUniform1i( uniforms.get("fogType").getLocation(), 0 );
+			gl.glUniform1i( uniforms.get(FOG_TYPE).getLocation(), 0 );
 			oldFogType = 0;
 			sceneFogType = 0;
 
@@ -211,7 +213,7 @@ public final class SpritePlugin extends Plugin
 
 			if ( oldFogType != fogType ) {
 
-				gl.glUniform1i( uniforms.get("fogType").getLocation(), fogType );
+				gl.glUniform1i( uniforms.get(FOG_TYPE).getLocation(), fogType );
 				oldFogType = fogType;
 
 			}
@@ -237,7 +239,6 @@ public final class SpritePlugin extends Plugin
 			gl.glUniform1f( uniforms.get("rotation").getLocation(), (float)material.getRotation() );
 			gl.glUniform2fv( uniforms.get("scale").getLocation(), 2, new float[]{(float)spriteScale.getX(), (float)spriteScale.getY()}, 0 );
 
-			//	renderer.setBlending( sprite.blending, sprite.blendEquation, sprite.blendSrc, sprite.blendDst );
 			getRenderer().setBlending( material.getBlending() );
 			getRenderer().setDepthTest( material.isDepthTest() );
 			getRenderer().setDepthWrite( material.isDepthWrite() );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S00122 - Statements should be on separate lines.
squid:S2184 - Math operands should be cast before assignment.
squid:S00115 - Constant names should comply with a naming convention.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1192 - String literals should not be duplicated.
squid:S1905 - Redundant casts should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S2184
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1905
Please let me know if you have any questions.
George Kankava