### PR TITLE
multiple code improvements: squid:S00122, squid:S1301, squid:SwitchLastCaseIsDefaultCheck, squid:S1854, squid:CommentedOutCodeLine, squid:UselessParenthesesCheck

### DIFF
--- a/extensions/parallax-controllers/src/org/parallax3d/parallax/controllers/FirstPersonControls.java
+++ b/extensions/parallax-controllers/src/org/parallax3d/parallax/controllers/FirstPersonControls.java
@@ -129,7 +129,7 @@ public class FirstPersonControls extends Controls implements TouchMoveHandler, T
 	 */
 	public void update( double delta ) 
 	{
-		double actualMoveSpeed = 0;
+		double actualMoveSpeed;
 		double actualLookSpeed;
 		
 		if ( this.freeze ) 
@@ -177,7 +177,7 @@ public class FirstPersonControls extends Controls implements TouchMoveHandler, T
 
 			this.lon += this.mouseX * actualLookSpeed;
 			if( this.lookVertical ) 
-				this.lat -= this.mouseY * actualLookSpeed; // * this.invertVertical?-1:1;
+				this.lat -= this.mouseY * actualLookSpeed;
 
 			this.lat = Math.max( - 85.0, Math.min( 85.0, this.lat ) );
 			this.phi = ( 90.0 - this.lat ) * Math.PI / 180.0;
@@ -198,7 +198,10 @@ public class FirstPersonControls extends Controls implements TouchMoveHandler, T
 			verticalLookRatio = Math.PI / ( this.verticalMax - this.verticalMin );
 
 		this.lon += this.mouseX * actualLookSpeed;
-		if( this.lookVertical ) this.lat -= this.mouseY * actualLookSpeed * verticalLookRatio;
+		if( this.lookVertical ) 
+		{
+			this.lat -= this.mouseY * actualLookSpeed * verticalLookRatio;
+		}
 
 		this.lat = Math.max( - 85.0, Math.min( 85.0, this.lat ) );
 		this.phi = ( 90.0 - this.lat ) * Math.PI / 180.0;
@@ -226,25 +229,23 @@ public class FirstPersonControls extends Controls implements TouchMoveHandler, T
 
 	@Override
 	public void onTouchDown(int screenX, int screenY, int pointer, int button) {
-		if ( this.activeLook )
+		if ( this.activeLook && button == Input.Buttons.LEFT)
 		{
-			switch ( button )
-			{
-				case Input.Buttons.LEFT: this.moveForward = true; break;
-				case Input.Buttons.RIGHT: this.moveBackward = true; break;
-			}
+			this.moveForward = true;
+		} else if (this.activeLook && button == Input.Buttons.RIGHT)
+		{
+			this.moveBackward = true;
 		}
 	}
 
 	@Override
 	public void onTouchUp(int screenX, int screenY, int pointer, int button) {
-		if ( this.activeLook )
+		if ( this.activeLook && button == Input.Buttons.LEFT)
 		{
-			switch ( button )
-			{
-				case Input.Buttons.LEFT: this.moveForward = false; break;
-				case Input.Buttons.RIGHT: this.moveBackward = false; break;
-			}
+			this.moveForward = false;
+		} else if(this.activeLook && button == Input.Buttons.RIGHT) 
+		{
+			this.moveBackward = false;
 		}
 	}
 
@@ -253,21 +254,30 @@ public class FirstPersonControls extends Controls implements TouchMoveHandler, T
 		switch( keycode )
 		{
 			case KeyCodes.KEY_UP:
-			case KeyCodes.KEY_W: this.moveForward = true; break;
+			case KeyCodes.KEY_W: 
+				this.moveForward = true; break;
 
 			case KeyCodes.KEY_LEFT:
-			case KeyCodes.KEY_A: this.moveLeft = true; break;
+			case KeyCodes.KEY_A: 
+				this.moveLeft = true; break;
 
 			case KeyCodes.KEY_DOWN:
-			case KeyCodes.KEY_S: this.moveBackward = true; break;
+			case KeyCodes.KEY_S: 
+				this.moveBackward = true; break;
 
 			case KeyCodes.KEY_RIGHT:
-			case KeyCodes.KEY_D: this.moveRight = true; break;
+			case KeyCodes.KEY_D: 
+				this.moveRight = true; break;
 
-			case KeyCodes.KEY_R: this.moveUp = true; break;
-			case KeyCodes.KEY_F: this.moveDown = true; break;
+			case KeyCodes.KEY_R: 
+				this.moveUp = true; break;
+			case KeyCodes.KEY_F: 
+				this.moveDown = true; break;
 
-			case KeyCodes.KEY_Q: this.freeze = !this.freeze; break;
+			case KeyCodes.KEY_Q: 
+				this.freeze = !this.freeze; break;
+			default:
+				break;
 		}
 	}
 
@@ -276,19 +286,27 @@ public class FirstPersonControls extends Controls implements TouchMoveHandler, T
 		switch( keycode )
 		{
 			case KeyCodes.KEY_UP:
-			case KeyCodes.KEY_W: this.moveForward = false; break;
+			case KeyCodes.KEY_W: 
+				this.moveForward = false; break;
 
 			case KeyCodes.KEY_LEFT:
-			case KeyCodes.KEY_A: this.moveLeft = false; break;
+			case KeyCodes.KEY_A: 
+				this.moveLeft = false; break;
 
 			case KeyCodes.KEY_DOWN:
-			case KeyCodes.KEY_S: this.moveBackward = false; break;
+			case KeyCodes.KEY_S: 
+				this.moveBackward = false; break;
 
 			case KeyCodes.KEY_RIGHT:
-			case KeyCodes.KEY_D: this.moveRight = false; break;
+			case KeyCodes.KEY_D: 
+				this.moveRight = false; break;
 
-			case KeyCodes.KEY_R: this.moveUp = false; break;
-			case KeyCodes.KEY_F: this.moveDown = false; break;
+			case KeyCodes.KEY_R: 
+				this.moveUp = false; break;
+			case KeyCodes.KEY_F: 
+				this.moveDown = false; break;
+			default:
+				break;
 		}
 	}
 }

--- a/extensions/parallax-controllers/src/org/parallax3d/parallax/controllers/FlyControls.java
+++ b/extensions/parallax-controllers/src/org/parallax3d/parallax/controllers/FlyControls.java
@@ -64,10 +64,7 @@ public final class FlyControls extends Controls implements TouchMoveHandler, Tou
 	public FlyControls(Object3D object, RenderingContext context)
 	{
 		super(object, context);
-			
-//		if(getWidget().getClass() != RootPanel.class)
-//			getWidget().getElement().setAttribute( "tabindex", "-1" );
-		
+
 		this.viewHalfX = context.getWidth() / 2.0;
 		this.viewHalfY = context.getHeight() / 2.0;
 
@@ -126,23 +123,37 @@ public final class FlyControls extends Controls implements TouchMoveHandler, Tou
 		switch( keycode )
 		{
 
-			case KeyCodes.KEY_W: this.moveState.forward = false; break;
-			case KeyCodes.KEY_S: this.moveState.back = false; break;
+			case KeyCodes.KEY_W: 
+				this.moveState.forward = false; break;
+			case KeyCodes.KEY_S: 
+				this.moveState.back = false; break;
 
-			case KeyCodes.KEY_A: this.moveState.left = false; break;
-			case KeyCodes.KEY_D: this.moveState.right = false; break;
+			case KeyCodes.KEY_A: 
+				this.moveState.left = false; break;
+			case KeyCodes.KEY_D: 
+				this.moveState.right = false; break;
 
-			case KeyCodes.KEY_R: this.moveState.up = false; break;
-			case KeyCodes.KEY_F: this.moveState.down = false; break;
+			case KeyCodes.KEY_R: 
+				this.moveState.up = false; break;
+			case KeyCodes.KEY_F: 
+				this.moveState.down = false; break;
 
-			case KeyCodes.KEY_UP: this.moveState.pitchUp = false; break;
-			case KeyCodes.KEY_DOWN: this.moveState.pitchDown = 0; break;
+			case KeyCodes.KEY_UP: 
+				this.moveState.pitchUp = false; break;
+			case KeyCodes.KEY_DOWN: 
+				this.moveState.pitchDown = 0; break;
 
-			case KeyCodes.KEY_LEFT: this.moveState.yawLeft = 0; break;
-			case KeyCodes.KEY_RIGHT: this.moveState.yawRight = false; break;
+			case KeyCodes.KEY_LEFT: 
+				this.moveState.yawLeft = 0; break;
+			case KeyCodes.KEY_RIGHT: 
+				this.moveState.yawRight = false; break;
 
-			case KeyCodes.KEY_Q: this.moveState.rollLeft = false; break;
-			case KeyCodes.KEY_E: this.moveState.rollRight = false; break;
+			case KeyCodes.KEY_Q: 
+				this.moveState.rollLeft = false; break;
+			case KeyCodes.KEY_E: 
+				this.moveState.rollRight = false; break;
+			default:
+				break;
 
 		}
 
@@ -158,23 +169,37 @@ public final class FlyControls extends Controls implements TouchMoveHandler, Tou
 
 		switch( keycode )
 		{
-			case KeyCodes.KEY_W: this.moveState.forward = true; break;
-			case KeyCodes.KEY_S: this.moveState.back = true; break;
+			case KeyCodes.KEY_W: 
+				this.moveState.forward = true; break;
+			case KeyCodes.KEY_S: 
+				this.moveState.back = true; break;
 
-			case KeyCodes.KEY_A: this.moveState.left = true; break;
-			case KeyCodes.KEY_D: this.moveState.right = true; break;
+			case KeyCodes.KEY_A: 
+				this.moveState.left = true; break;
+			case KeyCodes.KEY_D: 
+				this.moveState.right = true; break;
 
-			case KeyCodes.KEY_R: this.moveState.up = true; break;
-			case KeyCodes.KEY_F: this.moveState.down = true; break;
+			case KeyCodes.KEY_R: 
+				this.moveState.up = true; break;
+			case KeyCodes.KEY_F: 
+				this.moveState.down = true; break;
 
-			case KeyCodes.KEY_UP: this.moveState.pitchUp = true; break;
-			case KeyCodes.KEY_DOWN: this.moveState.pitchDown = 1; break;
+			case KeyCodes.KEY_UP: 
+				this.moveState.pitchUp = true; break;
+			case KeyCodes.KEY_DOWN: 
+				this.moveState.pitchDown = 1; break;
 
-			case KeyCodes.KEY_LEFT: this.moveState.yawLeft = 1; break;
-			case KeyCodes.KEY_RIGHT: this.moveState.yawRight = true; break;
+			case KeyCodes.KEY_LEFT: 
+				this.moveState.yawLeft = 1; break;
+			case KeyCodes.KEY_RIGHT: 
+				this.moveState.yawRight = true; break;
 
-			case KeyCodes.KEY_Q: this.moveState.rollLeft = true; break;
-			case KeyCodes.KEY_E: this.moveState.rollRight = true; break;
+			case KeyCodes.KEY_Q: 
+				this.moveState.rollLeft = true; break;
+			case KeyCodes.KEY_E: 
+				this.moveState.rollRight = true; break;
+			default:
+				break;
 		}
 
 		this.updateMovementVector();
@@ -193,10 +218,12 @@ public final class FlyControls extends Controls implements TouchMoveHandler, Tou
 		} 
 		else 
 		{
-			switch ( button )
+			if ( button == Input.Buttons.LEFT )
 			{
-			case Input.Buttons.LEFT: this.moveState.forward = false; break;
-			case Input.Buttons.RIGHT: this.moveState.forward = false; break;
+				this.moveState.forward = false;
+			} else if( button == Input.Buttons.RIGHT )
+			{
+				this.moveState.forward = false;
 			}
 		}
 
@@ -212,10 +239,12 @@ public final class FlyControls extends Controls implements TouchMoveHandler, Tou
 		} 
 		else 
 		{
-			switch ( button )
+			if( button == Input.Buttons.LEFT )
 			{
-			case Input.Buttons.LEFT: this.moveState.forward = true; break;
-			case Input.Buttons.RIGHT: this.moveState.forward = false; break;
+				this.moveState.forward = true;
+			} else if( button == Input.Buttons.RIGHT )
+			{
+				this.moveState.forward = false;
 			}
 		}
 	}
@@ -234,15 +263,15 @@ public final class FlyControls extends Controls implements TouchMoveHandler, Tou
 	{
 		int forward = ( this.moveState.forward || ( this.isAutoForward && !this.moveState.back ) ) ? 1 : 0;
 
-		this.moveVector.setX( - ((this.moveState.left) ? 1 : 0)    + ((this.moveState.right) ? 1 : 0) );
-		this.moveVector.setY( - ((this.moveState.down) ? 1 : 0)    + ((this.moveState.up) ? 1 : 0) );
-		this.moveVector.setZ( - forward + ((this.moveState.back) ? 1 : 0) );
+		this.moveVector.setX( - (this.moveState.left ? 1 : 0)    + (this.moveState.right ? 1 : 0) );
+		this.moveVector.setY( - (this.moveState.down ? 1 : 0)    + (this.moveState.up ? 1 : 0) );
+		this.moveVector.setZ( - forward + (this.moveState.back ? 1 : 0) );
 	}
 
 	private void updateRotationVector()
 	{
-		this.rotationVector.setX( - this.moveState.pitchDown + ((this.moveState.pitchUp) ? 1 : 0) );
-		this.rotationVector.setY( - ((this.moveState.yawRight) ? 1 : 0)  + this.moveState.yawLeft );
-		this.rotationVector.setZ( - ((this.moveState.rollRight) ? 1 : 0) + ((this.moveState.rollLeft) ? 1 : 0) );
+		this.rotationVector.setX( - this.moveState.pitchDown + (this.moveState.pitchUp ? 1 : 0) );
+		this.rotationVector.setY( - (this.moveState.yawRight ? 1 : 0)  + this.moveState.yawLeft );
+		this.rotationVector.setZ( - (this.moveState.rollRight ? 1 : 0) + (this.moveState.rollLeft ? 1 : 0) );
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00122 - Statements should be on separate lines.
squid:S1301 - "switch" statements should have at least 3 "case" clauses.
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S1854 - Dead stores should be removed.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S1301
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava