### PR TITLE
multiple code improvements: squid:S1118, squid:UselessParenthesesCheck, squid:S1905, squid:S1125, squid:S00122, squid:S00117, squid:CommentedOutCodeLine, squid:S1068, squid:S2184, squid:S1155

### DIFF
--- a/parallax/src/org/parallax3d/parallax/graphics/core/BufferGeometry.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/core/BufferGeometry.java
@@ -504,9 +504,9 @@ public class BufferGeometry extends AbstractGeometry
 
 					for ( int i = start, il = start + count; i < il; i += 3 ) {
 
-						vA = ( index + (int)indices.get( i     ) ) * 3;
-						vB = ( index + (int)indices.get( i + 1 ) ) * 3;
-						vC = ( index + (int)indices.get( i + 2 ) ) * 3;
+						vA = ( index + indices.get( i     ) ) * 3;
+						vB = ( index + indices.get( i + 1 ) ) * 3;
+						vC = ( index + indices.get( i + 2 ) ) * 3;
 
 						pA.fromArray( positions, vA );
 						pB.fromArray( positions, vB );
@@ -705,7 +705,7 @@ public class BufferGeometry extends AbstractGeometry
 			newVerticeMaps = 0;
 
 			for ( int vo = 0; vo < 3; vo ++ ) {
-				int vid = (int)indices.get( findex * 3 + vo );
+				int vid = indices.get( findex * 3 + vo );
 				if ( vertexMap.get( vid ) == - 1 ) {
 					//Unmapped vertice
 					faceVertices.set( vo * 2 , vid);
@@ -724,14 +724,14 @@ public class BufferGeometry extends AbstractGeometry
 
 			int faceMax = vertexPtr + newVerticeMaps;
 			if ( faceMax > ( offset.index + size ) ) {
-				BufferGeometry.DrawCall new_offset = new BufferGeometry.DrawCall(indexPtr, 0, vertexPtr );
-				offsets.add( new_offset );
-				offset = new_offset;
+				BufferGeometry.DrawCall newOffset = new BufferGeometry.DrawCall(indexPtr, 0, vertexPtr );
+				offsets.add( newOffset );
+				offset = newOffset;
 
 				//Re-evaluate reused vertices in light of new offset.
 				for ( int v = 0; v < 6; v += 2 ) {
-					int new_vid = faceVertices.get( v + 1 );
-					if ( new_vid > - 1 && new_vid < offset.index )
+					int newVid = faceVertices.get( v + 1 );
+					if ( newVid > - 1 && newVid < offset.index )
 						faceVertices.set( v + 1 , - 1);
 				}
 			}
@@ -739,14 +739,14 @@ public class BufferGeometry extends AbstractGeometry
 			//Reindex the face.
 			for ( int v = 0; v < 6; v += 2 ) {
 				int vid = faceVertices.get( v );
-				int new_vid = faceVertices.get( v + 1 );
+				int newVid = faceVertices.get( v + 1 );
 
-				if ( new_vid == - 1 )
-					new_vid = vertexPtr ++;
+				if ( newVid == - 1 )
+					newVid = vertexPtr ++;
 
-				vertexMap.set( vid , new_vid);
-				revVertexMap.set( new_vid , vid);
-				sortedIndices.set( indexPtr ++ , new_vid - offset.index); //XXX overflows at 16bit
+				vertexMap.set( vid , newVid);
+				revVertexMap.set( newVid , vid);
+				sortedIndices.set( indexPtr ++ , (float)newVid - offset.index); //XXX overflows at 16bit
 				offset.count ++;
 			}
 		}

--- a/parallax/src/org/parallax3d/parallax/graphics/core/Geometry.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/core/Geometry.java
@@ -504,7 +504,7 @@ public class Geometry extends AbstractGeometry
 
 			face = this.faces.get( f );
 
-			if(face.getVertexNormals().size() > 0) {
+			if(!face.getVertexNormals().isEmpty()) {
 				face.getVertexNormals().set(0, vertices[ face.a ].clone() );
 				face.getVertexNormals().set(1, vertices[ face.b ].clone() );
 				face.getVertexNormals().set(2, vertices[ face.c ].clone() );
@@ -794,7 +794,9 @@ public class Geometry extends AbstractGeometry
 
 			Vector3 vertexCopy = vertex.clone();
 
-			if ( matrix != null ) vertexCopy.apply( matrix );
+			if ( matrix != null ) {
+				vertexCopy.apply( matrix );
+			}
 
 			vertices1.add( vertexCopy );
 
@@ -838,7 +840,6 @@ public class Geometry extends AbstractGeometry
 
 				Color color = faceVertexColors.get( j );
 				faceCopy.vertexColors.add( color.clone() );
-//				faceCopy.vertexColors.add( color );
 
 			}
 

--- a/parallax/src/org/parallax3d/parallax/graphics/core/GeometryObject.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/core/GeometryObject.java
@@ -40,8 +40,6 @@ public abstract class GeometryObject extends Object3D
 
 	private double _oldLineWidth = -1;
 
-	private int[] tmpBufArray = {0};
-
 	public GeometryObject(AbstractGeometry geometry, Material material) {
 		this.geometry = geometry;
 		this.material = material;
@@ -137,10 +135,18 @@ public abstract class GeometryObject extends Object3D
 
 					int size = 1;		// "f" and "i"
 
-					if ( attribute.type == Attribute.TYPE.V2 ) size = 2;
-					else if ( attribute.type == Attribute.TYPE.V3 ) size = 3;
-					else if ( attribute.type == Attribute.TYPE.V4 ) size = 4;
-					else if ( attribute.type == Attribute.TYPE.C  ) size = 3;
+					if ( attribute.type == Attribute.TYPE.V2 ) {
+						size = 2;
+					}
+					else if ( attribute.type == Attribute.TYPE.V3 ) {
+						size = 3;
+					}
+					else if ( attribute.type == Attribute.TYPE.V4 ) {
+						size = 4;
+					}
+					else if ( attribute.type == Attribute.TYPE.C  ) {
+						size = 3;
+					}
 
 					attribute.size = size;
 					attribute.array = Float32Array.create(nvertices * size);

--- a/parallax/src/org/parallax3d/parallax/graphics/core/Object3D.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/core/Object3D.java
@@ -663,7 +663,9 @@ public class Object3D
 	 */
 	public Object3D getObjectById(int id, boolean recursive ) {
 
-		if ( this.id == id ) return this;
+		if ( this.id == id ) {
+			return this;
+		}
 
 		for ( int i = 0, l = this.children.size(); i < l; i ++ ) {
 
@@ -689,7 +691,9 @@ public class Object3D
 	 */
 	public Object3D getObjectByName( String name, boolean recursive ) {
 
-		if ( this.name.equals( name ) ) return this;
+		if ( this.name.equals( name ) ) {
+			return this;
+		}
 
 		for ( int i = 0, l = this.children.size(); i < l; i ++ ) {
 
@@ -800,7 +804,9 @@ public class Object3D
 	 */
 	public void traverseVisible ( Traverse traverse ) {
 
-		if ( this.visible == false ) return;
+		if ( !this.visible ) {
+			return;
+		}
 
 		traverse.callback(this);
 
@@ -830,9 +836,11 @@ public class Object3D
 	 */
 	public void updateMatrixWorld(boolean force)
 	{
-		if ( this.matrixAutoUpdate == true ) this.updateMatrix();
+		if ( this.matrixAutoUpdate ) {
+			this.updateMatrix();
+		}
 
-		if ( this.matrixWorldNeedsUpdate == true || force == true ) {
+		if ( this.matrixWorldNeedsUpdate || force ) {
 
 			if ( this.parent == null ) {
 
@@ -898,7 +906,7 @@ public class Object3D
 
 		object.isFrustumCulled = this.isFrustumCulled;
 
-		if ( recursive == true ) {
+		if ( recursive ) {
 
 			for ( int i = 0; i < this.children.size(); i ++ ) {
 

--- a/parallax/src/org/parallax3d/parallax/graphics/core/Raycaster.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/core/Raycaster.java
@@ -203,7 +203,7 @@ public class Raycaster
 
 		object.raycast( raycaster, intersects );
 
-		if ( recursive == true ) {
+		if ( recursive ) {
 
 			List<Object3D> children = object.children;
 

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/CurveUtils.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/CurveUtils.java
@@ -32,6 +32,8 @@ import org.parallax3d.parallax.system.ThreejsObject;
 @ThreejsObject("THREE.CurveUtils")
 public class CurveUtils
 {
+	private CurveUtils() {}
+
 	/**
 	 * This method calculates tangent of Quadratic Bezier Curve.
 	 *

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/FontUtils.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/FontUtils.java
@@ -29,13 +29,14 @@ public class FontUtils
 {
 	public static final double EPSILON = 0.0000000001;
 
+	private FontUtils() {}
 
 	/*
 	 * @param contour
 	 * @param result
-	 * 			There will be generated List of List of {@link Vector2}
+	 * There will be generated List of List of {@link Vector2}
 	 * @param vertIndices
-	 * 			There will be generated List of List of integer
+	 * There will be generated List of List of integer
 	 */
 	public static void triangulate( List<Vector2> contour, List<List<Vector2>> result, List<List<Integer>> vertIndices )
 	{
@@ -190,6 +191,6 @@ public class FontUtils
 		double cCROSSap = cX * apy - cY * apx;
 		double bCROSScp = bX * cpy - bY * cpx;
 
-		return ( (aCROSSbp >= 0.0) && (bCROSScp >= 0.0) && (cCROSSap >= 0.0) );
+		return (aCROSSbp >= 0.0) && (bCROSScp >= 0.0) && (cCROSSap >= 0.0);
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1905 - Redundant casts should not be used.
squid:S1125 - Literal boolean values should not be used in condition expressions.
squid:S00122 - Statements should be on separate lines.
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1068 - Unused private fields should be removed.
squid:S2184 - Math operands should be cast before assignment.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S1125
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S2184
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava