### PR TITLE
multiple code improvements: squid:S1118, squid:S2114, squid:S1155

### DIFF
--- a/parallax/src/org/parallax3d/parallax/graphics/extras/SceneUtils.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/SceneUtils.java
@@ -40,6 +40,8 @@ import org.parallax3d.parallax.graphics.scenes.Scene;
 @ThreejsObject("THREE.SceneUtils")
 public class SceneUtils
 {
+	private SceneUtils() {}
+
 	/**
 	 * This method creates multi-material 3D object which contains Mesh objects
 	 * in amount of the materials list size. Here are every Mesh object will use

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/ShapeUtils.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/ShapeUtils.java
@@ -39,6 +39,8 @@ import org.parallax3d.parallax.math.Vector2;
 public class ShapeUtils
 {
 
+	private ShapeUtils() {}
+
 	/**
 	 * Remove holes from the Shape
 	 *
@@ -202,7 +204,7 @@ public class ShapeUtils
 			verts.add(trianglea);
 			verts.add(triangleb);
 
-			shape.removeAll(shape);
+			shape.clear();
 
 			shape.addAll(tmpShape1);
 			shape.addAll(tmpHole1);

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/UniformsUtils.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/UniformsUtils.java
@@ -31,6 +31,8 @@ import org.parallax3d.parallax.system.ThreejsObject;
 @ThreejsObject("THREE.UniformsUtils")
 public class UniformsUtils
 {
+	private UniformsUtils() {}
+
 	/**
 	 * Merge two uniforms into one new result uniform.
 	 *

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/core/Path.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/core/Path.java
@@ -254,7 +254,7 @@ public class Path extends CurvePath {
 					cpx1 = (Double) args.get(0);
 					cpy1 = (Double) args.get(1);
 
-					if (points.size() > 0) {
+					if (!points.isEmpty()) {
 						Vector2 laste = points.get(points.size() - 1);
 
 						cpx0 = laste.getX();
@@ -288,7 +288,7 @@ public class Path extends CurvePath {
 					cpx2 = (Double) args.get(2);
 					cpy2 = (Double) args.get(3);
 
-					if (points.size() > 0) {
+					if (!points.isEmpty()) {
 						Vector2 laste = points.get(points.size() - 1);
 
 						cpx0 = laste.getX();
@@ -436,7 +436,7 @@ public class Path extends CurvePath {
 
 		List<Path> subPaths = extractSubpaths(this.actions);
 
-		if(subPaths.size() ==0 )
+		if(subPaths.isEmpty())
 			return shapes;
 
 		if(noHoles)
@@ -565,7 +565,7 @@ public class Path extends CurvePath {
 
 			}
 			// console.log("ambiguous: ", ambiguous);
-			if (toChange.size() > 0) {
+			if (!toChange.isEmpty()) {
 
 				// console.log("to change: ", toChange);
 				if (!ambiguous) newShapeHoles = betterShapeHoles;
@@ -606,7 +606,7 @@ public class Path extends CurvePath {
 
 			if ( action == PATH_ACTIONS.MOVE_TO ) {
 
-				if ( lastPath.actions.size() != 0 ) {
+				if ( !lastPath.actions.isEmpty() ) {
 
 					subPaths.add( lastPath );
 					lastPath = new Path();
@@ -623,7 +623,7 @@ public class Path extends CurvePath {
 				lastPath.bezierCurveTo((Double) args.get(0), (Double) args.get(1), (Double) args.get(2), (Double) args.get(3), (Double) args.get(4), (Double) args.get(5));
 		}
 
-		if ( lastPath.actions.size() != 0 ) {
+		if ( !lastPath.actions.isEmpty() ) {
 
 			subPaths.add( lastPath );
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S2114 - Collections should not be passed as arguments to their own methods.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S2114
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava