### PR TITLE
multiple code improvements: squid:S1905, squid:S1068, squid:S1155, squid:S1854, squid:CommentedOutCodeLine, squid:S1118

### DIFF
--- a/parallax/src/org/parallax3d/parallax/graphics/extras/core/Curve.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/core/Curve.java
@@ -198,7 +198,7 @@ public abstract class Curve
 		double segmentLength = lengthAfter - lengthBefore;
 
 		// determine where we are between the 'before' and 'after' points
-		double segmentFraction = (targetArcLength - lengthBefore) / (double)segmentLength;
+		double segmentFraction = (targetArcLength - lengthBefore) / segmentLength;
 
 		// add that fractional amount to t
 		return (high + segmentFraction) / ((double)arcLengths.size() - 1.0);
@@ -211,7 +211,7 @@ public abstract class Curve
 	 */
 	public Vector2 getNormalVector( double t )
 	{
-		Vector2 vec = (Vector2) this.getTangent( t );
+		Vector2 vec = this.getTangent( t );
 		return new Vector2( -vec.getY() , vec.getX() );
 	}
 

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/core/CurvePath.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/core/CurvePath.java
@@ -82,8 +82,8 @@ public class CurvePath extends Curve
 		// TODO Test
 		// and verify for vector3 (needs to implement equals)
 		// Add a line curve if start and end of lines are not connected
-		Vector2 startPoint = (Vector2) getCurves().get(0).getPoint(0);
-		Vector2 endPoint = (Vector2) getCurves().get(this.curves.size() - 1 ).getPoint(1);
+		Vector2 startPoint = getCurves().get(0).getPoint(0);
+		Vector2 endPoint = getCurves().get(this.curves.size() - 1 ).getPoint(1);
 
 		if (!startPoint.equals(endPoint))
 			this.curves.add( new LineCurve(endPoint, startPoint) );
@@ -117,7 +117,7 @@ public class CurvePath extends Curve
 
 				double u = 1.0 - diff / curve.getLength();
 
-				return (Vector2) curve.getPointAt( u );
+				return curve.getPointAt( u );
 			}
 
 			i ++;

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/core/ExtrudeGeometry.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/core/ExtrudeGeometry.java
@@ -73,8 +73,6 @@ public class ExtrudeGeometry extends Geometry
 		public int extrudeMaterial;
 	}
 
-	private static final double RAD_TO_DEGREES = 180.0 / Math.PI;
-
 	private static Vector2 __v1 = new Vector2();
 	private static Vector2 __v2 = new Vector2();
 	private static Vector2 __v3 = new Vector2();
@@ -104,7 +102,7 @@ public class ExtrudeGeometry extends Geometry
 	{
 		super();
 
-		if(shapes.size() > 0)
+		if(!shapes.isEmpty())
 			this.shapebb = shapes.get( shapes.size() - 1 ).getBoundingBox();
 
 		this.options = options;
@@ -182,7 +180,6 @@ public class ExtrudeGeometry extends Geometry
 			}
 
 			// If vertices are in order now, we shouldn't need to worry about them again (hopefully)!
-			reverse = false;
 		}
 
 		localFaces = ShapeUtils.triangulateShape ( vertices, holes );
@@ -251,7 +248,6 @@ public class ExtrudeGeometry extends Geometry
 			for ( int i = 0, il = contour.size(); i < il; i ++ )
 			{
 				Vector2 vert = scalePt2( contour.get( i ), contourMovements.get( i ), bs );
-				//vert = scalePt( contour[ i ], contourCentroid, bs, false );
 				v( vert.getX(), vert.getY(),  - z );
 			}
 
@@ -264,13 +260,11 @@ public class ExtrudeGeometry extends Geometry
 				for ( int i = 0, il = ahole.size(); i < il; i++ )
 				{
 					Vector2 vert = scalePt2( ahole.get( i ), oneHoleMovements.get( i ), bs );
-					//vert = scalePt( ahole[ i ], holesCentroids[ h ], bs, true );
 					v( vert.getX(), vert.getY(),  -z );
 				}
 			}
 		}
 
-//		bs = bevelSize;
 
 		// Back facing vertices
 
@@ -286,7 +280,6 @@ public class ExtrudeGeometry extends Geometry
 			}
 			else
 			{
-				// v( vert.x, vert.y + extrudePts[ 0 ].y, extrudePts[ 0 ].x );
 				normal.copy(splineTube.getNormals().get(0)).multiply(vert.getX());
 				binormal.copy(splineTube.getBinormals().get(0)).multiply(vert.getY());
 				position2.copy((Vector3)extrudePts.get(0)).add(normal).add(binormal);
@@ -312,8 +305,6 @@ public class ExtrudeGeometry extends Geometry
 				}
 				else
 				{
-					// v( vert.x, vert.y + extrudePts[ s - 1 ].y, extrudePts[ s - 1 ].x );
-
 					normal.copy(splineTube.getNormals().get(s)).multiply(vert.getX());
 					binormal.copy(splineTube.getBinormals().get(s)).multiply(vert.getY());
 
@@ -391,12 +382,12 @@ public class ExtrudeGeometry extends Geometry
 		double x = - Math.cos( anglec );
 		double y = - Math.sin( anglec );
 
-		return new Vector2( x, y ); //.normalize();
+		return new Vector2( x, y );
 	}
 
 	private Vector2 scalePt2 ( Vector2 pt, Vector2 vec, double size )
 	{
-		return (Vector2) vec.clone().multiply( size ).add( pt );
+		return vec.clone().multiply( size ).add( pt );
 	}
 
 	/*
@@ -604,6 +595,8 @@ public class ExtrudeGeometry extends Geometry
 
 	public static class WorldUVGenerator
 	{
+		private WorldUVGenerator() {}
+
 		public static List<Vector2> generateTopUV( Geometry geometry, int indexA, int indexB, int indexC )
 		{
 			double ax = geometry.getVertices().get( indexA ).getX();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1905 - Redundant casts should not be used.
squid:S1068 - Unused private fields should be removed.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1854 - Dead stores should be removed.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava