### PR TITLE
multiple code improvements: squid:S1481, squid:S1854, squid:S2185, squid:S1905, squid:UselessParenthesesCheck, squid:S1192, squid:S1213, squid:S2131, squid:S1155

### DIFF
--- a/parallax/src/org/parallax3d/parallax/graphics/extras/core/ShapeGeometry.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/core/ShapeGeometry.java
@@ -80,7 +80,6 @@ public class ShapeGeometry extends Geometry {
      */
     public void addShape ( final Shape shape, final ShapeGeometryParameters options )
     {
-        final int curveSegments = options.curveSegments;
         final int material = options.material;
         final int shapesOffset = this.getVertices().size();
         final List<Vector2> arrVertice = shape.getTransformedPoints();
@@ -103,10 +102,7 @@ public class ShapeGeometry extends Geometry {
                     Collections.reverse( hole );
                 }
             }
-
             // If vertices are in order now, we shouldn't need to worry about them again (hopefully)!
-            reverse = false;
-
         }
 
         final List< List< Integer > > arrFace = ShapeUtils.triangulateShape( arrVertice, arrHole );

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/curves/SplineCurve3Closed.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/curves/SplineCurve3Closed.java
@@ -49,7 +49,7 @@ public class SplineCurve3Closed extends Curve
 		int intPoint = (int) Math.floor( point );
 
 		double weight = point - intPoint;
-		intPoint += intPoint > 0 ? 0 : ( Math.floor( Math.abs( intPoint ) / points.size() ) + 1 ) * points.size();
+		intPoint += intPoint > 0 ? 0 : ( Math.abs( intPoint ) / points.size() + 1 ) * points.size();
 
 		int c0 = ( intPoint - 1 ) % points.size();
 		int c1 = ( intPoint ) % points.size();

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/geometries/BoxGeometry.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/geometries/BoxGeometry.java
@@ -121,7 +121,7 @@ public final class BoxGeometry extends Geometry
 			{
 				Vector3 vector = new Vector3();
 
-				double u1 = (double)( ix * segment_width - width_half ) * udir;
+				double u1 = ( ix * segment_width - width_half ) * udir;
 				if(u.equals("x"))
 					vector.setX(u1);
 				else if(u.equals("y"))
@@ -129,7 +129,7 @@ public final class BoxGeometry extends Geometry
 				else if(u.equals("z"))
 					vector.setZ(u1);
 
-				double v1 = (double)( iy * segment_height - height_half ) * vdir;
+				double v1 = ( iy * segment_height - height_half ) * vdir;
 				if(v.equals("x"))
 					vector.setX(v1);
 				else if(v.equals("y"))

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/geometries/RingGeometry.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/geometries/RingGeometry.java
@@ -44,7 +44,7 @@ public class RingGeometry extends Geometry {
 		phiSegments = Math.max( 1, phiSegments );
 
 		double radius = innerRadius;
-		double radiusStep = ( ( outerRadius - innerRadius ) / phiSegments );
+		double radiusStep = ( outerRadius - innerRadius ) / phiSegments;
 
 		List<Vector2> uvs = new ArrayList<Vector2>();
 

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/geometries/TubeGeometry.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/geometries/TubeGeometry.java
@@ -113,7 +113,7 @@ public final class TubeGeometry extends Geometry
 		{
 			for ( int j = 0; j < segmentsRadius; j++ )
 			{
-				int ip = ( closed ) ? (i + 1) % segments : i + 1;
+				int ip = closed ? (i + 1) % segments : i + 1;
 				int jp = (j + 1) % segmentsRadius;
 
 				int a = this.grid.get( i ).get( j );		// *** NOT NECESSARILY PLANAR ! ***

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/helpers/BoxHelper.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/helpers/BoxHelper.java
@@ -32,6 +32,8 @@ import org.parallax3d.parallax.system.gl.arrays.Float32Array;
 @ThreejsObject("THREE.BoxHelper")
 public class BoxHelper extends Line 
 {
+	private static final String POSITION = "position";
+
 	public BoxHelper(Mesh object)
 	{
 		super(new BufferGeometry(), new LineBasicMaterial(), Line.MODE.PIECES);
@@ -41,7 +43,7 @@ public class BoxHelper extends Line
 		material.setColor(new Color(0xffff00));
 
 
-		geometry.addAttribute( "position", new BufferAttribute( Float32Array.create(72), 3 ) );
+		geometry.addAttribute( POSITION, new BufferAttribute( Float32Array.create(72), 3 ) );
 
 		update( object );
 
@@ -77,7 +79,7 @@ public class BoxHelper extends Line
 		7: max.x, min.y, min.z
 		*/
 
-		Float32Array vertices = (Float32Array) ((BufferGeometry)this.geometry).getAttribute("position").getArray();
+		Float32Array vertices = (Float32Array) ((BufferGeometry)this.geometry).getAttribute(POSITION).getArray();
 
 		vertices.set(0, max.getX()); vertices.set(1, max.getY()); vertices.set(2, max.getZ());
 		vertices.set(3, min.getX()); vertices.set(4, max.getY()); vertices.set(5, max.getZ());
@@ -119,7 +121,7 @@ public class BoxHelper extends Line
 		vertices.set(66, max.getX()); vertices.set(67, min.getY()); vertices.set(68, max.getZ());
 		vertices.set(69, max.getX()); vertices.set(70, min.getY()); vertices.set(71, min.getZ());
 
-		((BufferGeometry)this.geometry).getAttribute("position").setNeedsUpdate(true);
+		((BufferGeometry)this.geometry).getAttribute(POSITION).setNeedsUpdate(true);
 
 		this.geometry.computeBoundingSphere();
 

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/helpers/CameraHelper.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/helpers/CameraHelper.java
@@ -46,6 +46,9 @@ import org.parallax3d.parallax.graphics.objects.Line;
 @ThreejsObject("THREE.CameraHelper")
 public class CameraHelper extends Line
 {
+	Vector3 _vector = new Vector3();
+	Camera _camera = new Camera();
+
 	private Camera camera;
 
 	private FastMap<List<Integer>> pointMap;
@@ -142,9 +145,6 @@ public class CameraHelper extends Line
 
 		this.pointMap.get( id ).add(((Geometry)getGeometry()).getVertices().size() - 1 );
 	}
-
-	Vector3 _vector = new Vector3();
-	Camera _camera = new Camera();
 
 	public void update()
 	{

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/helpers/VertexNormalsHelper.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/helpers/VertexNormalsHelper.java
@@ -38,6 +38,7 @@ public class VertexNormalsHelper extends Line
 	Mesh object;
 	double size;
 	Matrix3 normalMatrix;
+	Vector3 v1 = new Vector3();
 
 	public VertexNormalsHelper(Mesh object)
 	{
@@ -90,7 +91,6 @@ public class VertexNormalsHelper extends Line
 
 	}
 
-	Vector3 v1 = new Vector3();
 	public void update()
 	{
 

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/helpers/WireframeHelper.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/helpers/WireframeHelper.java
@@ -40,6 +40,8 @@ import org.parallax3d.parallax.system.gl.arrays.Uint32Array;
 @ThreejsObject("THREE.WireframeHelper")
 public class WireframeHelper extends Line {
 
+	private static final String POSITION = "position";
+
 	public WireframeHelper(GeometryObject object)
 	{
 		this(object, new Color(0xffffff));
@@ -76,7 +78,7 @@ public class WireframeHelper extends Line {
 					edge[ 1 ] = face.getFlat()[( j + 1 ) % 3 ];
 					Arrays.sort(edge);
 
-					String key = "" + edge[0] + edge[1];
+					String key = Integer.toString(edge[0]) + Integer.toString( edge[1]);
 
 					if ( !hash.containsKey(key) )
 					{
@@ -107,7 +109,7 @@ public class WireframeHelper extends Line {
 
 			}
 
-			geometry.addAttribute( "position", new BufferAttribute( coords, 3 ) );
+			geometry.addAttribute( POSITION, new BufferAttribute( coords, 3 ) );
 
 
 
@@ -118,12 +120,12 @@ public class WireframeHelper extends Line {
 			// Indexed BufferGeometry
 			if ( ((BufferGeometry)object.getGeometry()).getAttribute("index") != null ) {
 
-				Float32Array vertices = (Float32Array) ((BufferGeometry)object.getGeometry()).getAttribute("position").getArray();
+				Float32Array vertices = (Float32Array) ((BufferGeometry)object.getGeometry()).getAttribute(POSITION).getArray();
 				Uint16Array indices = (Uint16Array) ((BufferGeometry)object.getGeometry()).getAttribute("index").getArray();
 				List<DrawCall> drawcalls = ((BufferGeometry)object.getGeometry()).getDrawcalls();
 				int numEdges = 0;
 
-				if ( drawcalls.size() == 0 )
+				if ( drawcalls.isEmpty() )
 				{
 					drawcalls = Arrays.asList( new DrawCall(0, indices.getLength(), 9) );
 				}
@@ -145,7 +147,7 @@ public class WireframeHelper extends Line {
 							edge[ 1 ] = index + indices.get( i + ( j + 1 ) % 3 );
 							Arrays.sort(edge);
 
-							String key = "" + edge[0] + edge[1];
+							String key = Integer.toString(edge[0]) + Integer.toString(edge[1]);
 
 							if (  !hash.containsKey(key) )
 							{
@@ -177,14 +179,14 @@ public class WireframeHelper extends Line {
 
 				}
 
-				geometry.addAttribute( "position", new BufferAttribute( coords, 3 ) );
+				geometry.addAttribute( POSITION, new BufferAttribute( coords, 3 ) );
 
 			}
 			// non-indexed BufferGeometry
 			else
 			{
 
-				Float32Array vertices = (Float32Array) ((BufferGeometry)object.getGeometry()).getAttribute("position").getArray();
+				Float32Array vertices = (Float32Array) ((BufferGeometry)object.getGeometry()).getAttribute(POSITION).getArray();
 				int numEdges = vertices.getLength() / 3;
 				int numTris = numEdges / 3;
 
@@ -210,7 +212,7 @@ public class WireframeHelper extends Line {
 
 				}
 
-				geometry.addAttribute( "position", new BufferAttribute( coords, 3 ) );
+				geometry.addAttribute( POSITION, new BufferAttribute( coords, 3 ) );
 
 			}
 

--- a/parallax/src/org/parallax3d/parallax/graphics/lights/AmbientLight.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/lights/AmbientLight.java
@@ -48,7 +48,7 @@ public final class AmbientLight extends Light
 		@Override
 		public void reset()
 		{
-			this.colors = (Float32Array) Float32Array.createArray();
+			this.colors = Float32Array.createArray();
 			for(int i = 0; i < 3; i++)
 				this.colors.set(i, 0.0);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1481 - Unused local variables should be removed.
squid:S1854 - Dead stores should be removed.
squid:S2185 - Silly math should not be performed.
squid:S1905 - Redundant casts should not be used.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1192 - String literals should not be duplicated.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1481
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S2185
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava