### PR TITLE
multiple code improvements: squid:S2786, squid:S1192, squid:UselessParenthesesCheck, squid:S1125, squid:S00122, squid:S1854, squid:S1481, squid:S1155, squid:S1066

### DIFF
--- a/parallax/src/org/parallax3d/parallax/graphics/materials/Material.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/materials/Material.java
@@ -56,7 +56,7 @@ public abstract class Material
 	/**
 	 * Material sides
 	 */
-	public static enum SIDE
+	public enum SIDE
 	{
 		FRONT,
 		BACK,
@@ -66,7 +66,7 @@ public abstract class Material
 	/**
 	 * Shading
 	 */
-	public static enum SHADING
+	public enum SHADING
 	{
 		NO, // NoShading = 0;
 		FLAT, // FlatShading = 1;
@@ -76,7 +76,7 @@ public abstract class Material
 	/**
 	 * Colors
 	 */
-	public static enum COLORS
+	public enum COLORS
 	{
 		NO, // NoColors = 0;
 		FACE, // FaceColors = 1;
@@ -86,7 +86,7 @@ public abstract class Material
 	/**
 	 * Blending modes
 	 */
-	public static enum BLENDING
+	public enum BLENDING
 	{
 		NO, // NoBlending = 0;
 		NORMAL, // NormalBlending = 1;
@@ -97,7 +97,7 @@ public abstract class Material
 		CUSTOM // CustomBlending = 6;
 	}
 
-	private static enum SHADER_DEFINE {
+	private enum SHADER_DEFINE {
 		VERTEX_TEXTURES, GAMMA_INPUT, GAMMA_OUTPUT,
 
 		MAX_DIR_LIGHTS, // param
@@ -122,19 +122,21 @@ public abstract class Material
 
 		USE_FOG, FOG_EXP2, METAL;
 
+		private static final String DEFINE = "#define ";
+
 		public String getValue()
 		{
-			return "#define " + this.name();
+			return DEFINE + this.name();
 		}
 
 		public String getValue(int param)
 		{
-			return "#define " + this.name() + " " + param;
+			return DEFINE + this.name() + " " + param;
 		}
 
 		public String getValue(double param)
 		{
-			return "#define " + this.name() + " " + param;
+			return DEFINE + this.name() + " " + param;
 		}
 	}
 
@@ -501,15 +503,15 @@ public abstract class Material
 
 	public void updateProgramParameters(ProgramParameters parameters)
 	{
-		parameters.map          = (this instanceof HasMap         && ((HasMap)this).getMap() != null);
-		parameters.envMap       = (this instanceof HasEnvMap      && ((HasEnvMap)this).getEnvMap() != null);
-		parameters.lightMap     = (this instanceof HasLightMap    &&  ((HasLightMap)this).getLightMap() != null);
-		parameters.bumpMap      = (this instanceof HasBumpMap     &&  ((HasBumpMap)this).getBumpMap() != null);
-		parameters.normalMap    = (this instanceof HasNormalMap   &&  ((HasNormalMap)this).getNormalMap() != null);
-		parameters.specularMap  = (this instanceof HasSpecularMap &&  ((HasSpecularMap)this).getSpecularMap() != null);
-		parameters.alphaMap     = (this instanceof HasAlphaMap    &&  ((HasAlphaMap)this).getAlphaMap() != null);
+		parameters.map          = this instanceof HasMap         && ((HasMap)this).getMap() != null;
+		parameters.envMap       = this instanceof HasEnvMap      && ((HasEnvMap)this).getEnvMap() != null;
+		parameters.lightMap     = this instanceof HasLightMap    &&  ((HasLightMap)this).getLightMap() != null;
+		parameters.bumpMap      = this instanceof HasBumpMap     &&  ((HasBumpMap)this).getBumpMap() != null;
+		parameters.normalMap    = this instanceof HasNormalMap   &&  ((HasNormalMap)this).getNormalMap() != null;
+		parameters.specularMap  = this instanceof HasSpecularMap &&  ((HasSpecularMap)this).getSpecularMap() != null;
+		parameters.alphaMap     = this instanceof HasAlphaMap    &&  ((HasAlphaMap)this).getAlphaMap() != null;
 
-		parameters.vertexColors = (this instanceof HasVertexColors && ((HasVertexColors)this).isVertexColors() != Material.COLORS.NO);
+		parameters.vertexColors = this instanceof HasVertexColors && ((HasVertexColors)this).isVertexColors() != Material.COLORS.NO;
 
 		parameters.sizeAttenuation = this instanceof PointCloudMaterial && ((PointCloudMaterial)this).isSizeAttenuation();
 
@@ -938,7 +940,9 @@ public abstract class Material
 	public void deallocate( GLRenderer renderer )
 	{
 		int program = getShader().getProgram();
-		if ( program == 0 ) return;
+		if ( program == 0 ) {
+			return;
+		}
 
 //		getShader().setPrecision(null);
 
@@ -960,7 +964,7 @@ public abstract class Material
 			}
 		}
 
-		if ( deleteProgram == true )
+		if ( deleteProgram )
 		{
 
 			renderer.gl.glDeleteProgram(program);

--- a/parallax/src/org/parallax3d/parallax/graphics/objects/Line.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/objects/Line.java
@@ -55,7 +55,7 @@ public class Line extends GeometryObject
 	/**
 	 * In OpenGL terms, LineStrip is the classic GL_LINE_STRIP and LinePieces is the equivalent to GL_LINES. 
 	 */
-	public static enum MODE
+	public enum MODE
 	{
 		/**
 		 * Will draw a series of segments connecting each point 
@@ -139,7 +139,7 @@ public class Line extends GeometryObject
 		sphere.copy( geometry.getBoundingSphere() );
 		sphere.apply( this.matrixWorld );
 
-		if ( raycaster.getRay().isIntersectionSphere( sphere ) == false ) {
+		if ( !raycaster.getRay().isIntersectionSphere( sphere ) ) {
 
 			return;
 
@@ -158,11 +158,15 @@ public class Line extends GeometryObject
 
 			double distSq = ray.distanceSqToSegment( vertices.get( i ), vertices.get( i + 1 ), interRay, interSegment );
 
-			if ( distSq > precisionSq ) continue;
+			if ( distSq > precisionSq ) {
+				continue;
+			}
 
 			double distance = ray.getOrigin().distanceTo( interRay );
 
-			if ( distance < raycaster.getNear() || distance > raycaster.getFar() ) continue;
+			if ( distance < raycaster.getNear() || distance > raycaster.getFar() ) {
+				continue;
+			}
 
 			Raycaster.Intersect intersect = new Raycaster.Intersect();
 			intersect.distance = distance;
@@ -276,7 +280,6 @@ public class Line extends GeometryObject
 		List<Double> lineDistances = geometry.getLineDistances();
 
 		int vl = vertices.size();
-		int cl = colors.size();
 		int dl = lineDistances.size();
 
 		Float32Array vertexArray = geometry.__vertexArray;

--- a/parallax/src/org/parallax3d/parallax/graphics/objects/Mesh.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/objects/Mesh.java
@@ -108,7 +108,7 @@ public class Mesh extends GeometryObject
 		if(this.getGeometry() instanceof BufferGeometry)
 			return;
 
-		if ( ((Geometry)this.getGeometry()).getMorphTargets() != null && ((Geometry)this.getGeometry()).getMorphTargets().size() > 0 ) {
+		if ( ((Geometry)this.getGeometry()).getMorphTargets() != null && !((Geometry)this.getGeometry()).getMorphTargets().isEmpty() ) {
 
 			this.morphTargetBase = -1;
 			this.morphTargetForcedOrder = new ArrayList<Integer>();
@@ -138,7 +138,7 @@ public class Mesh extends GeometryObject
 		_sphere.copy( geometry.getBoundingSphere() );
 		_sphere.apply( this.matrixWorld );
 
-		if ( raycaster.getRay().isIntersectionSphere( _sphere ) == false )
+		if ( !raycaster.getRay().isIntersectionSphere( _sphere ) )
 		{
 			return;
 		}
@@ -148,12 +148,9 @@ public class Mesh extends GeometryObject
 		_inverseMatrix.getInverse( this.matrixWorld );
 		_ray.copy( raycaster.getRay() ).apply( _inverseMatrix );
 
-		if ( geometry.getBoundingBox() != null )
+		if ( geometry.getBoundingBox() != null && !_ray.isIntersectionBox( geometry.getBoundingBox() ) )
 		{
-			if ( _ray.isIntersectionBox( geometry.getBoundingBox() ) == false )
-			{
-				return;
-			}
+			return;
 		}
 
 		double precision = Raycaster.PRECISION;
@@ -164,7 +161,7 @@ public class Mesh extends GeometryObject
 
 			if ( material == null ) return;
 
-			BufferGeometry bGeometry = ((BufferGeometry) geometry);
+			BufferGeometry bGeometry = (BufferGeometry) geometry;
 
 			if ( bGeometry.getAttribute("index") != null ) {
 
@@ -172,7 +169,7 @@ public class Mesh extends GeometryObject
 				Float32Array positions = (Float32Array)bGeometry.getAttribute("position").getArray();
 				List<BufferGeometry.DrawCall> offsets = bGeometry.getDrawcalls();
 
-				if ( offsets.size() == 0 )
+				if ( offsets.isEmpty() )
 				{
 					offsets.add(new BufferGeometry.DrawCall(0, indices.getLength(), 0));
 				}
@@ -186,9 +183,9 @@ public class Mesh extends GeometryObject
 					for ( int i = start, il = start + count; i < il; i += 3 )
 					{
 
-						int a = index + (int)indices.get( i );
-						int b = index + (int)indices.get( i + 1 );
-						int c = index + (int)indices.get( i + 2 );
+						int a = index + indices.get( i );
+						int b = index + indices.get( i + 1 );
+						int c = index + indices.get( i + 2 );
 
 						_vA.fromArray( positions, a * 3 );
 						_vB.fromArray( positions, b * 3 );
@@ -272,9 +269,9 @@ public class Mesh extends GeometryObject
 		} else if ( geometry instanceof Geometry ) {
 
 			boolean isFaceMaterial = this.getMaterial() instanceof MeshFaceMaterial;
-			List<Material> objectMaterials = isFaceMaterial == true ? ((MeshFaceMaterial)this.getMaterial()).getMaterials() : null;
+			List<Material> objectMaterials = isFaceMaterial ? ((MeshFaceMaterial)this.getMaterial()).getMaterials() : null;
 
-			Geometry aGeometry = ((Geometry) geometry);
+			Geometry aGeometry = (Geometry) geometry;
 
 			List<Vector3> vertices = aGeometry.getVertices();
 
@@ -282,7 +279,7 @@ public class Mesh extends GeometryObject
 
 				Face3 face = aGeometry.getFaces().get( f );
 
-				Material material = isFaceMaterial == true ? objectMaterials.get( face.getMaterialIndex() ) : this.getMaterial();
+				Material material = isFaceMaterial ? objectMaterials.get( face.getMaterialIndex() ) : this.getMaterial();
 
 				if ( material == null ) continue;
 
@@ -519,7 +516,7 @@ public class Mesh extends GeometryObject
 
 		}
 
-		if ( geometry.getSkinWeights().size() > 0 && geometry.getSkinIndices().size() > 0 ) {
+		if ( !geometry.getSkinWeights().isEmpty() && !geometry.getSkinIndices().isEmpty() ) {
 
 			geometryGroup.__skinIndexArray = Float32Array.create(nvertices * 4);
 			geometryGroup.__skinWeightArray = Float32Array.create(nvertices * 4);
@@ -728,9 +725,8 @@ public class Mesh extends GeometryObject
 				offset_line = 0,
 				offset_color = 0,
 				offset_skin = 0,
-				offset_morphTarget = 0,
-				offset_custom = 0,
-				offset_customSrc = 0;
+				offset_morphTarget,
+				offset_custom;
 
 		Float32Array vertexArray = geometryGroup.__vertexArray,
 				uvArray = geometryGroup.__uvArray,
@@ -769,8 +765,6 @@ public class Mesh extends GeometryObject
 		List<List<Vector2>>	obj_uvs2 = null;
 		if(geometry.getFaceVertexUvs().size() > 1)
 			obj_uvs2 = geometry.getFaceVertexUvs().get( 1 );
-
-		List<Color> obj_colors = geometry.getColors();
 
 		List<Vector4> obj_skinIndices = geometry.getSkinIndices(),
 				obj_skinWeights = geometry.getSkinWeights();
@@ -891,7 +885,7 @@ public class Mesh extends GeometryObject
 			 }
 		}
 
-		if ( obj_skinWeights.size() > 0 )
+		if ( !obj_skinWeights.isEmpty() )
 		{
 			for ( int f = 0, fl = chunk_faces3.size(); f < fl; f ++ )
 			{
@@ -1082,18 +1076,22 @@ public class Mesh extends GeometryObject
 
 		}
 
-		if ( dirtyUvs && obj_uvs != null &&  obj_uvs.size() > 0 )
+		if ( dirtyUvs && obj_uvs != null && !obj_uvs.isEmpty() )
 		{
 			for (int  f = 0, fl = chunk_faces3.size(); f < fl; f ++ )
 			{
 
 				int fi = chunk_faces3.get(f);
 
-				if(obj_uvs.size() <= fi) continue;
+				if(obj_uvs.size() <= fi) {
+					continue;
+				}
 
 				List<Vector2> uv = obj_uvs.get(fi);
 
-				if ( uv == null ) continue;
+				if ( uv == null ) {
+					continue;
+				}
 
 				for ( int i = 0; i < 3; i ++ ) {
 
@@ -1113,7 +1111,7 @@ public class Mesh extends GeometryObject
 			 }
 		 }
 
-		if (dirtyUvs && obj_uvs2 != null && obj_uvs2.size() > 0 )
+		if (dirtyUvs && obj_uvs2 != null && !obj_uvs2.isEmpty() )
 		{
 
 			for ( int f = 0, fl = chunk_faces3.size(); f < fl; f ++ )
@@ -1122,7 +1120,9 @@ public class Mesh extends GeometryObject
 
 				List<Vector2> uv2 = obj_uvs2.get(fi);
 
-				if ( uv2 == null ) continue;
+				if ( uv2 == null ) {
+					continue;
+				}
 
 				for ( int i = 0; i < 3; i ++ )
 				{
@@ -1180,10 +1180,11 @@ public class Mesh extends GeometryObject
 			{
 				Attribute customAttribute = geometryGroup.__webglCustomAttributesList.get(i);
 
-				if ( ! customAttribute.__original.needsUpdate ) continue;
+				if ( ! customAttribute.__original.needsUpdate ) {
+					continue;
+				}
 
 				offset_custom = 0;
-				offset_customSrc = 0;
 
 				if ( customAttribute.size == 1 )
 				{


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2786 - Nested "enum"s should not be declared static.
squid:S1192 - String literals should not be duplicated.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1125 - Literal boolean values should not be used in condition expressions.
squid:S00122 - Statements should be on separate lines.
squid:S1854 - Dead stores should be removed.
squid:S1481 - Unused local variables should be removed.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1066 - Collapsible "if" statements should be merged.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2786
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1125
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1481
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1066
Please let me know if you have any questions.
George Kankava