### PR TITLE
multiple code improvements: squid:S2184, squid:S1850, squid:S1155, squid:S1905, squid:S1118, squid:S1854, squid:CommentedOutCodeLine, squid:S00122, squid:S2131, squid:S1125

### DIFF
--- a/extensions/parallax-controllers/src/org/parallax3d/parallax/controllers/FlyControls.java
+++ b/extensions/parallax-controllers/src/org/parallax3d/parallax/controllers/FlyControls.java
@@ -287,15 +287,15 @@ public final class FlyControls extends Controls implements TouchMoveHandler, Tou
 	{
 		int forward = ( this.moveState.forward || ( this.isAutoForward && !this.moveState.back ) ) ? 1 : 0;
 
-		this.moveVector.setX( - (this.moveState.left ? 1 : 0)    + (this.moveState.right ? 1 : 0) );
-		this.moveVector.setY( - (this.moveState.down ? 1 : 0)    + (this.moveState.up ? 1 : 0) );
-		this.moveVector.setZ( - forward + (this.moveState.back ? 1 : 0) );
+		this.moveVector.setX( - (this.moveState.left ? 1D : 0D)    + (this.moveState.right ? 1D : 0D) );
+		this.moveVector.setY( - (this.moveState.down ? 1D : 0D)    + (this.moveState.up ? 1D : 0D) );
+		this.moveVector.setZ( - (double)forward + (this.moveState.back ? 1D : 0D) );
 	}
 
 	private void updateRotationVector()
 	{
 		this.rotationVector.setX( - this.moveState.pitchDown + (this.moveState.pitchUp ? 1 : 0) );
 		this.rotationVector.setY( - (this.moveState.yawRight ? 1 : 0)  + this.moveState.yawLeft );
-		this.rotationVector.setZ( - (this.moveState.rollRight ? 1 : 0) + (this.moveState.rollLeft ? 1 : 0) );
+		this.rotationVector.setZ( - (this.moveState.rollRight ? 1D : 0D) + (this.moveState.rollLeft ? 1D : 0D) );
 	}
 }

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/core/CurvePath.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/core/CurvePath.java
@@ -167,7 +167,7 @@ public class CurvePath extends Curve
 	 */
 	public Box3 getBoundingBox()
 	{
-		List<Vector2> points = (ArrayList)this.getPoints();
+		List<Vector2> points = this.getPoints();
 
 		double maxX, maxY;
 		double minX, minY;

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/core/Path.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/core/Path.java
@@ -712,7 +712,7 @@ public class Path extends CurvePath {
 
 	public List<Vector2>  getTransformedSpacedPoints( boolean closedPath, List<CurvePath> bends )
 	{
-		List<Vector2> oldPts = (List<Vector2>)(List<?>)this.getSpacedPoints( closedPath );
+		List<Vector2> oldPts = this.getSpacedPoints( closedPath );
 
 		for ( int i = 0; i < bends.size(); i ++ )
 			oldPts = getWrapPoints( oldPts, bends.get( i ) );
@@ -772,7 +772,7 @@ public class Path extends CurvePath {
 
 	public List<Vector2> getTransformedPoints( boolean closedPath, List<CurvePath> bends )
 	{
-		List<Vector2> oldPts = (List<Vector2>)(List<?>)this.getPoints( closedPath ); // getPoints getSpacedPoints
+		List<Vector2> oldPts = this.getPoints( closedPath ); // getPoints getSpacedPoints
 
 		for ( int i = 0; i < bends.size(); i ++ )
 			oldPts = this.getWrapPoints( oldPts, bends.get( i ) );

--- a/parallax/src/org/parallax3d/parallax/graphics/extras/modifiers/TessellateModifier.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/extras/modifiers/TessellateModifier.java
@@ -63,8 +63,6 @@ public class TessellateModifier extends Modifier {
 
             Face3 face = geometry.getFaces().get( i );
 
-            if ( face instanceof Face3 ) {
-
                 int a = face.getA();
                 int b = face.getB();
                 int c = face.getC();
@@ -204,7 +202,7 @@ public class TessellateModifier extends Modifier {
 
                     for ( int j = 0, jl = geometry.getFaceVertexUvs().size(); j < jl; j ++ ) {
 
-                        if ( geometry.getFaceVertexUvs().get( j ).size() > 0) {
+                        if ( !geometry.getFaceVertexUvs().get( j ).isEmpty() ) {
 
                             List<Vector2> uvs = geometry.getFaceVertexUvs().get( j ).get( i );
 
@@ -258,8 +256,6 @@ public class TessellateModifier extends Modifier {
                     }
 
                 }
-
-            }
 
         }
 

--- a/parallax/src/org/parallax3d/parallax/graphics/renderers/GLExtensions.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/renderers/GLExtensions.java
@@ -28,9 +28,11 @@ public final class GLExtensions {
 
 	static final List<GLES20Ext.List> extensions = new ArrayList<>();
 
+	private GLExtensions() {}
+
 	public static boolean isSupported(GL20 gl, GLES20Ext.List id) {
 
-		if(extensions.size() == 0)
+		if(extensions.isEmpty())
 		{
 			String vals = gl.glGetString(GL20.GL_EXTENSIONS);
 			if(vals != null)
@@ -38,6 +40,6 @@ public final class GLExtensions {
 					extensions.add(GLES20Ext.List.valueOf(val));
 		}
 
-		return extensions.size() > 0 && extensions.contains( id );
+		return !extensions.isEmpty() && extensions.contains( id );
 	}
 }

--- a/parallax/src/org/parallax3d/parallax/graphics/renderers/ShadowMap.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/renderers/ShadowMap.java
@@ -161,7 +161,9 @@ public final class ShadowMap extends Plugin
 	public void render(GL20 gl, Camera camera, List<Light> sceneLights,
 					   int currentWidth, int currentHeight)
 	{
-		if ( ! ( isEnabled() && isAutoUpdate() ) ) return;
+		if ( ! ( isEnabled() && isAutoUpdate() ) ) {
+			return;
+		}
 
 		// set GL state for depth map
 
@@ -192,7 +194,9 @@ public final class ShadowMap extends Plugin
 		{
 			Light sceneLight = sceneLights.get( i );
 
-			if ( ! sceneLight.isCastShadow() ) continue;
+			if ( ! sceneLight.isCastShadow() ) {
+				continue;
+			}
 
 			if ( ( sceneLight instanceof DirectionalLight ) &&
 					((DirectionalLight)sceneLight).isShadowCascade() )
@@ -359,7 +363,7 @@ public final class ShadowMap extends Plugin
 				Material objectMaterial = getObjectMaterial( object );
 
 				boolean useMorphing = object.getGeometry() instanceof Geometry && ((Geometry)object.getGeometry()).getMorphTargets() != null
-						&& ((Geometry)object.getGeometry()).getMorphTargets().size() > 0
+						&& !((Geometry)object.getGeometry()).getMorphTargets().isEmpty()
 						&& objectMaterial instanceof HasSkinning &&
 						((HasSkinning)objectMaterial).isMorphTargets();
 
@@ -367,13 +371,8 @@ public final class ShadowMap extends Plugin
 						&& objectMaterial instanceof HasSkinning &&
 						((HasSkinning)objectMaterial).isSkinning();
 
-				Material material = null;
+				Material material;
 
-//				if ( object.customDepthMaterial ) {
-//
-//					material = object.customDepthMaterial;
-//
-//				} else
 				if ( useSkinning ) {
 
 					material = useMorphing ? this.depthMaterialMorphSkin : this.depthMaterialSkin;
@@ -446,12 +445,12 @@ public final class ShadowMap extends Plugin
 
 		if ( object.isVisible() ) {
 
-			List<GLObject> webglObjects = getRenderer()._webglObjects.get( object.getId() + "" );
+			List<GLObject> webglObjects = getRenderer()._webglObjects.get( Integer.toString(object.getId()) );
 
 			if ( webglObjects != null && object.isCastShadow() &&
-					(object.isFrustumCulled() == false ||
+					(!object.isFrustumCulled() ||
 							getRenderer()._frustum.isIntersectsObject(
-									(GeometryObject) object ) == true) ) {
+									(GeometryObject) object ) ) ) {
 
 				for ( int i = 0, l = webglObjects.size(); i < l; i ++ ) {
 
@@ -569,14 +568,26 @@ public final class ShadowMap extends Plugin
 
 			p.apply( shadowCamera.getMatrixWorldInverse() );
 
-			if ( p.getX() < this.min.getX() ) this.min.setX( p.getX() );
-			if ( p.getX() > this.max.getX() ) this.max.setX( p.getX() );
+			if ( p.getX() < this.min.getX() ) {
+				this.min.setX( p.getX() );
+			}
+			if ( p.getX() > this.max.getX() ) {
+				this.max.setX( p.getX() );
+			}
 
-			if ( p.getY() < this.min.getY() ) this.min.setY( p.getY() );
-			if ( p.getY() > this.max.getY() ) this.max.setY( p.getY() );
+			if ( p.getY() < this.min.getY() ) {
+				this.min.setY( p.getY() );
+			}
+			if ( p.getY() > this.max.getY() ) {
+				this.max.setY( p.getY() );
+			}
 
-			if ( p.getZ() < this.min.getZ() ) this.min.setZ( p.getZ() );
-			if ( p.getZ() > this.max.getZ() ) this.max.setZ( p.getZ() );
+			if ( p.getZ() < this.min.getZ() ) {
+				this.min.setZ( p.getZ() );
+			}
+			if ( p.getZ() > this.max.getZ() ) {
+				this.max.setZ( p.getZ() );
+			}
 
 		}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2184 - Math operands should be cast before assignment.
squid:S1850 - "instanceof" operators that always return "true" or "false" should be removed.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1905 - Redundant casts should not be used.
squid:S1118 - Utility classes should not have public constructors.
squid:S1854 - Dead stores should be removed.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S00122 - Statements should be on separate lines.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S1125 - Literal boolean values should not be used in condition expressions.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2184
https://dev.eclipse.org/sonar/rules/show/squid:S1850
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1125
Please let me know if you have any questions.
George Kankava