### PR TITLE
squid:S1118: Utility classes should not have public constructors

### DIFF
--- a/parallax/src/org/parallax3d/parallax/graphics/renderers/shaders/ChunksFragmentShader.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/renderers/shaders/ChunksFragmentShader.java
@@ -64,5 +64,7 @@ public class ChunksFragmentShader
 
 	public static String SPECULARMAP_PARS = Chunks.INSTANCE.getSpecularmapParsFragment().getText();
 	public static String SPECULARMAP = Chunks.INSTANCE.getSpecularmapFragment().getText();
-	
+
+	private ChunksFragmentShader() {} 
+
 }

--- a/platforms/parallax-gwt/src/com/google/gwt/webgl/client/WebGLUtil.java
+++ b/platforms/parallax-gwt/src/com/google/gwt/webgl/client/WebGLUtil.java
@@ -20,6 +20,8 @@ import static com.google.gwt.webgl.client.WebGLRenderingContext.*;
 
 public class WebGLUtil {
 
+	private WebGLUtil() {}
+
 	public static float[] createPerspectiveMatrix (int fieldOfViewVertical, float aspectRatio, float minimumClearance,
 		float maximumClearance) {
 		double fieldOfViewInRad = fieldOfViewVertical * Math.PI / 180.0;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1118: Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava