### PR TITLE
squid:S2583 Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/parallax/src/org/parallax3d/parallax/math/Ray.java
+++ b/parallax/src/org/parallax3d/parallax/math/Ray.java
@@ -426,9 +426,9 @@ public class Ray
 		// These lines also handle the case where tmin or tmax is NaN
 		// (result of 0 * Infinity). x !== x returns true if x is NaN
 
-		if ( tymin > tmin || tmin != tmin ) tmin = tymin;
+		if ( tymin > tmin || tymin != tmin ) tmin = tymin;
 
-		if ( tymax < tmax || tmax != tmax ) tmax = tymax;
+		if ( tymax < tmax || tymax != tmax ) tmax = tymax;
 
 		if ( invdirz >= 0 ) {
 
@@ -443,9 +443,9 @@ public class Ray
 
 		if ( ( tmin > tzmax ) || ( tzmin > tmax ) ) return null;
 
-		if ( tzmin > tmin || tmin != tmin ) tmin = tzmin;
+		if ( tzmin > tmin || tzmin != tmin ) tmin = tzmin;
 
-		if ( tzmax < tmax || tmax != tmax ) tmax = tzmax;
+		if ( tzmax < tmax || tzmax != tmax ) tmax = tzmax;
 
 		//return point closest to the ray (positive side)
 


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
You can find more information about the issue here
https://dev.eclipse.org/sonar/rules/show/squid:S2583
Please let me know if you have any questions.
George Kankava