### PR TITLE
multiple code improvements: squid:S2786, squid:S00116, squid:S1068, squid:CommentedOutCodeLine, squid:S1213, squid:S1149, squid:S1854

### DIFF
--- a/parallax/src/org/parallax3d/parallax/graphics/renderers/shaders/Shader.java
+++ b/parallax/src/org/parallax3d/parallax/graphics/renderers/shaders/Shader.java
@@ -41,7 +41,7 @@ public abstract class Shader
 	/**
 	 * Sets the Shader's precision value.
 	 */
-	public static enum PRECISION
+	public enum PRECISION
 	{
 		HIGHP,
 		MEDIUMP,
@@ -75,13 +75,12 @@ public abstract class Shader
 	private String vertexExtensions = "";
 	private String fragmentExtensions = "";
 
-	private boolean cache_areCustomAttributesDirty;
+	private boolean cacheAreCustomAttributesDirty;
 
 	private int id;
 
 	private static int shaderCounter;
-
-	private int[] tmpArray = {0};
+	private static String shaderReplaceArg = "[*]";
 
 	/**
 	 * This constructor will create new Shader instance.
@@ -208,15 +207,6 @@ public abstract class Shader
 
 		gl.glLinkProgram(this.program);
 
-//		if (!gl.getProgramParameterb(this.program, ProgramParameter.LINK_STATUS))
-//			Log.error("Could not initialise shader\n"
-//					+ "GL error: " + gl.getProgramInfoLog(program)
-//					+ "Shader: " + this.getClass().getName()
-//					+ "\n-----\nVERTEX:\n" + vertex
-//					+ "\n-----\nFRAGMENT:\n" + fragment
-//			);
-//
-//		else
 			Log.debug("Shader.initProgram(): shaders has been initialised");
 
 		// clean up
@@ -248,12 +238,6 @@ public abstract class Shader
 
 		gl.glShaderSource(shader, string);
 		gl.glCompileShader(shader);
-
-//		if (!App.gl.glGetShaderParameterb(shader, GL20.GL_COMPILE_STATUS))
-//		{
-//			Log.error(App.gl.getShaderInfoLog(shader));
-//			return null;
-//		}
 
 		return shader;
 	}
@@ -358,7 +342,7 @@ public abstract class Shader
 
 	public boolean areCustomAttributesDirty()
 	{
-		if(this.cache_areCustomAttributesDirty)
+		if(this.cacheAreCustomAttributesDirty)
 			return true;
 
 		if(getAttributes() == null)
@@ -368,7 +352,7 @@ public abstract class Shader
 		{
 			if ( attribute.needsUpdate )
 			{
-				this.cache_areCustomAttributesDirty = true;
+				this.cacheAreCustomAttributesDirty = true;
 				return true;
 			}
 		}
@@ -378,7 +362,7 @@ public abstract class Shader
 
 	public void clearCustomAttributes()
 	{
-		if(!this.cache_areCustomAttributesDirty)
+		if(!this.cacheAreCustomAttributesDirty)
 			return;
 
 		if(getAttributes() == null)
@@ -387,7 +371,7 @@ public abstract class Shader
 		for ( Attribute attribute: getAttributes().values() )
 		{
 			attribute.needsUpdate = false;
-			this.cache_areCustomAttributesDirty = false;
+			this.cacheAreCustomAttributesDirty = false;
 		}
 	}
 
@@ -413,22 +397,21 @@ public abstract class Shader
 		return Shader.updateShaderSource(src, mods);
 	}
 
-	private static String SHADER_REPLACE_ARG = "[*]";
 	public static String updateShaderSource(String src, String ... allMods)
 	{
-		if(src.indexOf(SHADER_REPLACE_ARG) >= 0)
+		if(src.indexOf(shaderReplaceArg) >= 0)
 		{
-			StringBuffer result = new StringBuffer();
+			StringBuilder result = new StringBuilder();
 			int s = 0;
-			int e = 0;
+			int e;
 
 			for ( String replace : allMods )
 			{
-				if((e = src.indexOf(SHADER_REPLACE_ARG, s)) >= 0)
+				if((e = src.indexOf(shaderReplaceArg, s)) >= 0)
 				{
 					result.append(src.substring(s, e));
 			        result.append(replace);
-			        s = e + SHADER_REPLACE_ARG.length();
+			        s = e + shaderReplaceArg.length();
 				}
 			}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2786 - Nested "enum"s should not be declared static.
squid:S00116 - Field names should comply with a naming convention.
squid:S1068 - Unused private fields should be removed.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S1854 - Dead stores should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2786
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
George Kankava