### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/extensions/parallax-renderer-css-gwt/pom.xml
+++ b/extensions/parallax-renderer-css-gwt/pom.xml
@@ -25,12 +25,7 @@
 			<version>${gwt.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>com.google.gwt</groupId>
-			<artifactId>gwt-dev</artifactId>
-			<version>${gwt.version}</version>
-			<scope>provided</scope>
-		</dependency>
+		
 	</dependencies>
 
 	<build>

--- a/extensions/parallax-renderer-raytracing-gwt/pom.xml
+++ b/extensions/parallax-renderer-raytracing-gwt/pom.xml
@@ -25,12 +25,7 @@
 			<version>${gwt.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>com.google.gwt</groupId>
-			<artifactId>gwt-dev</artifactId>
-			<version>${gwt.version}</version>
-			<scope>provided</scope>
-		</dependency>
+		
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,9 @@
                 <version>2.17</version>
                 <configuration>
                     <includes><include>**/*Test.java</include></includes>
+                	<parallel>classes</parallel>
+                	<useUnlimitedThreads>true</useUnlimitedThreads>
+
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
parallax-parent
parallax
parallax-gwt
parallax-android
parallax-controllers
parallax-loaders
parallax-renderer-plugins
parallax-renderer-raytracing-gwt
{groupId='com.google.gwt', artifactId='gwt-dev'}
parallax-renderer-css-gwt
{groupId='com.google.gwt', artifactId='gwt-dev'}


According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
